### PR TITLE
翻译 concurrency-overview

### DIFF
--- a/topics-zh-CN/concurrency-overview.md
+++ b/topics-zh-CN/concurrency-overview.md
@@ -3,7 +3,7 @@
 
 当你把 Android 的开发经验套用在 Kotlin 移动多平台（KMM）时，会发现在 iOS 平台是不同的状态和并发模型。也就是 Kotlin/Native 模型。[Kotlin/Native](https://kotlinlang.org/docs/reference/native-overview.html) 是一种将 Kotlin 代码编译为原生二进制文件的技术，可以在没有虚拟机的情况下运行，例如在 iOS 上运行。
 
-众所周知，不加限制地让多个线程同时使用可变内存是有风险的，容易出错。例如 Java， C++ 和 Swift/Objective-C 这些语言，允许多个线程不受限制的访问同一状态。并发问题与其他编程问题不同，常常很难复现。在本地开发时也许没有问题，或者只是零星出现。有时并发问题只能在生产环境下，有一定负载才会出现。
+众所周知，不加限制地让多个线程同时使用可变内存有风险且易出错。例如 Java， C++ 和 Swift/Objective-C 这些语言，允许多个线程不受限制的访问同一状态。并发问题与其他编程问题不同，常常很难复现。在本地开发时也许没有问题，或者只是零星出现。有时它只在生产环境下，加以一定负载才出现。
 
 总之，就算测试通过了，也不意味着你的代码没有问题。
 
@@ -45,7 +45,7 @@ fun simpleState(){
 data class SomeData(val s:String, val i:Int)
 ```
 
-接下来这个示例可能是不可变的，也可能是可变的。`SomeInterface` 内部的操作在编译期是未知的。Kotlin 不能在编译期静态的确认深度不可变性。
+接下来这个示例可能是不可变的，也可能是可变的。`SomeInterface` 内部的操作在编译期是未知的。Kotlin 不能在编译期静态地确定深层不可变性。
 
 ```kotlin
 data class SomeData(val s:String, val i:SomeInterface)
@@ -55,7 +55,7 @@ Kotlin/Native 需要验证状态的某些部分在运行时确实是不可变的
 
 Kotlin/Native 定义了一个新的运行时状态 _冻结（frozen）_。一个对象的任一实例都可能被冻结。如果一个对象是冻结的：
 
-1. 你不能改变其状态的任何部分。试图这样做会触发运行时异常：`InvalidMutabilityException`。一个被冻结的对象实例，百分百是运行时验证的，不可变的。
+1. 你不能改变其状态的任何部分。试图这样做会触发运行时异常：`InvalidMutabilityException`。一个被冻结的对象实例，百分百是运行时验证过不可变的。
 2. 它所引用的一切也都是被冻结的。它所引用的所有其他对象都被保证是冻结状态。也就是说当运行时需要确定一个对象是否可以与其他线程共享时，只需要检查该对象是否被冻结。如果是的话，整个图也被冻结了，可以安全地共享。
 
 Native 运行时给所有的类添加了一个扩展函数 `freeze()`。调用 `freeze()` 函数会冻结一个对象，并递归地冻结该对象所引用的内容。
@@ -142,9 +142,9 @@ val hello = "Hello" // 只有主线程可见
 
 Kotlin/Native 的并发规则需要对架构设计进行一些调整，但在库和新的最佳实践的帮助下，日常开发基本不会受到影响。实际上，遵循 Kotlin/Native 并发规则的跨平台代码会让 Kotlin 移动多平台（KMM）应用的并发性更加安全。你可以从这个[上手教程](https://play.kotlinlang.org/hands-on/Kotlin%20Native%20Concurrency/)开始尝试 Kotlin/Native 并发。
 
-Kotlin 移动多平台（KMM）应用中，Android 和 iOS 遵循各自平台的状态规则。一些大型应用的开发团队，会共享特别具体的功能代码，常在宿主平台进行并发性管理。这种情况需要直接冻结 Kotlin 返回的状态，但除此之外，还是简单明了的。
+Kotlin 移动多平台（KMM）应用中，Android 和 iOS 遵循各自平台的状态规则。一些大型应用的开发团队，会共享特别具体的功能代码，常在宿主平台进行并发性管理。这种情况需要直接冻结 Kotlin 返回的状态，但除此之外，还是简单直接的。
 
-一个更广泛的模型，即在 Kotlin 中管理并发，宿主机在其主线程上与共享代码进行通信，从状态管理的角度来看，这种模式更简单。使用 [`kotlinx.coroutines`](https://github.com/Kotlin/kotlinx.coroutines)之类的并发库，可以帮助自动化冻状态。你也可以利用[协程](https://kotlinlang.org/docs/reference/coroutines/coroutines-guide.html)，共享更多的代码来提升效率。
+一个更广泛的模型，即在 Kotlin 中管理并发，宿主平台在其主线程上与共享代码进行通信，从状态管理的角度来看，这种模式更简单。使用 [`kotlinx.coroutines`](https://github.com/Kotlin/kotlinx.coroutines)之类的并发库，可以帮助自动化冻。你也可以利用[协程](https://kotlinlang.org/docs/reference/coroutines/coroutines-guide.html)，共享更多的代码来提升效率。
 
 然而，目前 Kotlin/Native 的并发模型仍有一些不足之处。例如，移动开发者已经习惯了在线程之间自由地共享状态，并开发了一系列的方法和架构模式避免数据竞争。虽然使用 Kotlin/Native 可以在不阻塞主线程的情况下编写高效应用程序，但是学习成本过高。
 

--- a/topics-zh-CN/concurrency-overview.md
+++ b/topics-zh-CN/concurrency-overview.md
@@ -1,37 +1,25 @@
 [//]: # (title: Concurrency overview)
 [//]: # (auxiliary-id: Concurrency_Overview)
 
-When you extend your development experience from Android to Kotlin Multiplatform Mobile, you will encounter a different state 
-and concurrency model for iOS. This is a Kotlin/Native model. [Kotlin/Native](https://kotlinlang.org/docs/reference/native-overview.html) 
-is a technology for compiling Kotlin code to native binaries that can run without a virtual machine, for example on iOS. 
+当你把 Android 的开发经验套用在 Kotlin 移动多平台（KMM）时，会发现在 iOS 平台是不同的状态和并发模型。也就是 Kotlin/Native 模型。[Kotlin/Native](https://kotlinlang.org/docs/reference/native-overview.html) 是一种将 Kotlin 代码编译为原生二进制文件的技术，可以在没有虚拟机的情况下运行，例如在 iOS 上运行。
 
-Having mutable memory available to multiple threads at the same time, if unrestricted, is known to be risky and prone to error. 
-Languages like Java, C++, and Swift/Objective-C let multiple threads access the same state in an unrestricted way. Concurrency issues are unlike other programming issues in that they are 
-often very difficult to reproduce. You may not see them locally while developing, and they may happen sporadically. 
-And sometimes you can only see them in production under load.
+众所周知，不加限制地让多个线程同时使用可变内存是有风险的，容易出错。例如 Java， C++ 和 Swift/Objective-C 这些语言，允许多个线程不受限制的访问同一状态。并发问题与其他编程问题不同，常常很难复现。在本地开发时也许没有问题，或者只是零星出现。有时并发问题只能在生产环境下，有一定负载才会出现。
 
-In short, just because your tests pass, you can’t necessarily be sure that your code is OK.
+总之，就算测试通过了，也不意味着你的代码没有问题。
 
-Not all languages are designed this way. Javascript simply does not 
-allow you to access the same state concurrently. At the other end of the spectrum is Rust, with its
-language-level management of concurrency and states, which makes it very popular. 
+当然，也不是所有语言都采用这样设计。Javascript 简单的禁止了并发访问同一状态。另一个极端是 Rust，它提供语言级别的并发和状态管理，这使得它非常流行。
 
-## Rules for state sharing 
+## 状态共享的规则 
 
-Kotlin/Native introduces rules for sharing states between threads. These rules exist to prevent unsafe shared 
-access to mutable states. If you come from a JVM background and write concurrent code, you may need to change the way 
-you architect your data, but doing so will allow you to achieve the same results without risky side effects.
+Kotlin/Native 为线程间共享状态引入了一些规则。希望通过这些规则，防止不安全的共享访问可变状态。如果你有 JVM 的开发背景还写过并发代码，你可能需要改变数据架构的方式，但是这可以让你在没有风险副作用的情况下，实现相同的效果。
 
-It is also important to point out that there are [ways to work around these rules](concurrent-mutability.md). 
-The intent is to make working around these rules something that you rarely have to do, if ever.
+这里需要强调一下，有[绕过这些规则的方法](concurrent-mutability.md)。我们希望让你尽量避免绕开这些规则，条件允许的话。
 
-There are just two simple rules regarding state and concurrency.
+关于状态和并发只有两个简单的规则。
 
-### Rule 1: Mutable state == 1 thread
+### 规则 1： 可变状态 == 单线程
 
-If your state is mutable, only one thread can _see_ it at a time. Any regular class state that 
-you would normally use in Kotlin is considered by the Kotlin/Native runtime as _mutable_. If you aren't using concurrency, 
-Kotlin/Native behaves the same as any other Kotlin code, with the exception of [global state](#global-state).
+如果你的状态是可变的，那么它同一时间只对一个线程 _可见_。任何在 Kotlin 中正常使用的普通类状态都会被 Kotlin/Native 运行时当作 _可变的_ 。如果你没有使用并发，Kotlin/Native 的行为与其他 Kotlin 代码相同，除了[全局状态](#global-state)。
 
 ```kotlin
 data class SomeData(var count:Int)
@@ -39,48 +27,38 @@ data class SomeData(var count:Int)
 fun simpleState(){
     val sd = SomeData(42)
     sd.count++
-    println("My count is ${sd.count}") // It will be 43
+    println("My count is ${sd.count}") // 结果是 43
 }
 ```
 
-If there's only one thread, you won’t have concurrency issues. Technically this is referred 
-to as _thread confinement_, which means that you cannot change the UI from a background thread. Kotlin/Native's state rules 
-formalize that concept for all threads.
+如果仅有一个线程，你不会遇到并发问题。技术上，这被称为 _线程限制_ ，意味着你不能在后台线程修改 UI。Kotlin/Native 的状态规则为所有线程确立了这个概念。
 
-### Rule 2: Immutable state == many threads
+### 规则 2: 不可变状态 == 多线程
 
-If a state can't be changed, multiple threads can safely access it.
-In Kotlin/Native, _immutable_ doesn't mean everything is a `val`. It means _frozen state_.
+如果一个状态不能被改变，多线程可以安全地访问它。在 Kotlin/Native 中，_不可变_ 并不是说所有东西都是 `val` 的。它意味着 _冻结（frozen）状态_
 
-## Immutable and frozen state
+## 不可变和冻结状态
 
-The example below is immutable by definition – it has 2 `val` elements, and both are of final immutable types.
+下面的示例被定义成不可变的 — 它有两个 `val` 元素，都是 final 不可变类型。
 
 ```kotlin
 data class SomeData(val s:String, val i:Int)
 ```
 
-This next example may be immutable or mutable. It is not clear what `SomeInterface` will do internally at compile time. 
-In Kotlin, it is not possible to determine deep immutability statically at compile time.
+接下来这个示例可能是不可变的，也可能是可变的。`SomeInterface` 内部的操作在编译期是未知的。Kotlin 不能在编译期静态的确认深度不可变性。
 
 ```kotlin
 data class SomeData(val s:String, val i:SomeInterface)
 ```
 
-Kotlin/Native needs to verify that some part of a state really is immutable at runtime. The runtime could simply go 
-through the whole state and verify that each part is deeply immutable, but that would be inflexible. And if you needed 
-to do that every time the runtime wanted to check mutability, there would be significant consequences for performance.
+Kotlin/Native 需要验证状态的某些部分在运行时确实是不可变的。运行时可以简单地遍历整个状态，依次验证其每一部分的深度不可变性，但这样做很死板。并且，如果每次运行时想要检查可变性时，都要这样做的话，会带来严重的性能问题。
 
-Kotlin/Native defines a new runtime state called _frozen_. Any instance of an object may be frozen. If an object is frozen:
+Kotlin/Native 定义了一个新的运行时状态 _冻结（frozen）_。一个对象的任一实例都可能被冻结。如果一个对象是冻结的：
 
-1. You cannot change any part of its state. Attempting to do so will result in a runtime exception: `InvalidMutabilityException`. 
-A frozen object instance is 100%, runtime-verified, immutable.
-2. Everything it references is also frozen. All other objects it has a reference to are guaranteed to be frozen. This means that, 
-when the runtime needs to determine whether an object can be shared with another thread, it only needs to check whether that object 
-is frozen. If it is, the whole graph is also frozen and is safe to be shared.
+1. 你不能改变其状态的任何部分。试图这样做会触发运行时异常：`InvalidMutabilityException`。一个被冻结的对象实例，百分百是运行时验证的，不可变的。
+2. 它所引用的一切也都是被冻结的。它所引用的所有其他对象都被保证是冻结状态。也就是说当运行时需要确定一个对象是否可以与其他线程共享时，只需要检查该对象是否被冻结。如果是的话，整个图也被冻结了，可以安全地共享。
 
-The Native runtime adds an extension function `freeze()` to all classes. Calling `freeze()` will freeze an object, and everything 
-referenced by the object, recursively.
+Native 运行时给所有的类添加了一个扩展函数 `freeze()`。调用 `freeze()` 函数会冻结一个对象，并递归地冻结该对象所引用的内容。
 
 ```kotlin
 data class MoreData(val strData: String, var width: Float)
@@ -92,36 +70,33 @@ sd.freeze()
 
 ![Freezing state](freezing-state.png){animated="true"}
 
-* `freeze()` is a one-way operation. You can't _unfreeze_ something.
-* `freeze()` is not available in shared Kotlin code, but several libraries provide expect and actual declarations
- for using it in shared code. However, if you're using a concurrency library, like [`kotlinx.coroutines`](https://github.com/Kotlin/kotlinx.coroutines), it will 
-likely freeze data that crosses thread boundaries automatically. 
+* `freeze()` 是一个单向操作。你没法 _解冻（unfreeze）_。
+* `freeze()` 在共享的 Kotlin 代码中不可用，不过有几个库提供了 expect 和 actual 声明，以便在共享的代码里使用。不过，如果你使用了一个并发库，例如 [`kotlinx.coroutines`](https://github.com/Kotlin/kotlinx.coroutines)，它可能会自动冻结跨越线程边界的数据。
 
-`freeze` is not unique to Kotlin. You can also find it in [Ruby](https://www.honeybadger.io/blog/when-to-use-freeze-and-frozen-in-ruby/) and [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze).
+`freeze` 并不是 Kotlin 特有的。你可以在 [Ruby](https://www.honeybadger.io/blog/when-to-use-freeze-and-frozen-in-ruby/) 和 [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) 里找到它。
 
-## Global state
+## 全局状态
 
-Kotlin allows you to define a state as globally available. If left simply mutable, the global state would violate [_Rule 1_](#rule-1-mutable-state-1-thread).  
-To conform to Kotlin/Native's state rules, the global state has some special conditions. 
-These conditions freeze the state or make it visible only to a single thread.
+Kotlin 允许定义全局可用的状态。如果只是简单地保留可变性，这个全局状态就会违反 [_规则 1_](#rule-1-mutable-state-1-thread)。
+为了符合 Kotlin/Native 的状态规则，全局状态有一些特殊条件。这些条件可以冻结状态，或者使其只对单个线程可见。
 
-### Global `object`
+### 全局 `对象`
 
-Global `object` instances are frozen by default. This means that all threads can access them, but they are immutable. The following won't work.
+全局 `对象` 默认是冻结的。也就是所有线程都能访问，不过它是不可变的。以下代码不能正常工作。
 
 ```kotlin
 object SomeState{
     var count = 0
     fun add(){
-        count++ //This will throw an exception
+        count++ // 这里会抛异常
     }
 }
 ```
 
-Trying to change `count` will throw an exception because `SomeState` is frozen (which means all of its data is frozen).
+尝试修改 `count` 会触发异常，因为 `SomeState` 是被冻结的（它所引用的所有数据也是被冻结的）。
 
-You can make a global object thread _local_, which will allow it to be mutable and give each thread a copy of its state. 
-Annotate it with `@ThreadLocal`.
+你可以把全局对象变成线程 _局部的_，这就允许它是可变的，每一个线程持有一份状态的拷贝。
+对它使用 `@ThreadLocal` 注解。
 
 ```kotlin
 @ThreadLocal
@@ -133,61 +108,46 @@ object SomeState{
 }
 ```
 
-If different threads read `count`, they'll get different values, because each thread has its own copy.
+不同线程读取到的 `count` 是不同的，因为每个线程都有自己的副本。
 
-These global object rules also apply to companion objects.
+全局对象的规则同样适用于伴生对象。
 
 ```kotlin
 class SomeState{
     companion object{
         var count = 0
         fun add(){
-            count++ //This will throw an exception
+            count++ // 这里会抛异常
         }
     }
 }
 ```
 
-### Global properties
+### 全局属性
 
-Global properties are a special case. *They are only available to the main thread*, but they are mutable. Accessing them from 
-other threads will throw an exception.
+全局属性是一个特例，*它们只能被主线程访问*，是可变的。从其他线程访问全局属性会抛异常。
 
 ```kotlin
-val hello = "Hello" //Only main thread can see this
+val hello = "Hello" // 只有主线程可见
 ```
 
-You can annotate them with :
+你可以对全局属性使用以下注解：
 
-* `@SharedImmutable`, which will make them globally available but frozen.
-* `@ThreadLocal`, which will give each thread its own mutable copy.
+* `@SharedImmutable`，标记为全局可见，不过是冻结状态。
+* `@ThreadLocal`，每个线程持有一份拷贝。
 
-This rule applies to global properties with backing fields. Computed properties and global functions do not have the main 
-thread restriction.
+这条规则适用于拥有支持字段（backing filed）的全局属性。计算属性和全局函数不受主线程的限制。
 
-## Current and future models
+## 并发模型的现状和未来
 
-Kotlin/Native's concurrency rules will require some adjustment in architecture design, but with the help of libraries and
- new best practices, day to day development is basically unaffected. In fact, adhering to Kotlin/Native's rules regarding 
-multiplatform code will result in safer concurrency across the KMM application. You can try out the Kotlin/Native concurrency
-model in [this hands-on tutorial](https://play.kotlinlang.org/hands-on/Kotlin%20Native%20Concurrency/).
+Kotlin/Native 的并发规则需要对架构设计进行一些调整，但在库和新的最佳实践的帮助下，日常开发基本不会受到影响。实际上，遵循 Kotlin/Native 并发规则的跨平台代码会让 Kotlin 移动多平台（KMM）应用的并发性更加安全。你可以从这个[上手教程](https://play.kotlinlang.org/hands-on/Kotlin%20Native%20Concurrency/)开始尝试 Kotlin/Native 并发。
 
-In the KMM application, you have Android and iOS targets with different state rules. Some teams, generally ones working on 
-larger applications, share code for very specific functionality, and often manage concurrency in the host platform. 
-This will require explicit freezing of states returned from Kotlin, but otherwise, it is straightforward. 
+Kotlin 移动多平台（KMM）应用中，Android 和 iOS 遵循各自平台的状态规则。一些大型应用的开发团队，会共享特别具体的功能代码，常在宿主平台进行并发性管理。这种情况需要直接冻结 Kotlin 返回的状态，但除此之外，还是简单明了的。
 
-A more extensive model, where concurrency is managed in Kotlin 
-and the host communicates on its main thread to shared code, is simpler from a state management perspective. 
-Concurrency libraries, like [`kotlinx.coroutines`](https://github.com/Kotlin/kotlinx.coroutines), 
-will help automate freezing. You'll also be able to leverage the power of [coroutines](https://kotlinlang.org/docs/reference/coroutines/coroutines-guide.html) 
-in your code and increase efficiency by sharing more code.
+一个更广泛的模型，即在 Kotlin 中管理并发，宿主机在其主线程上与共享代码进行通信，从状态管理的角度来看，这种模式更简单。使用 [`kotlinx.coroutines`](https://github.com/Kotlin/kotlinx.coroutines)之类的并发库，可以帮助自动化冻状态。你也可以利用[协程](https://kotlinlang.org/docs/reference/coroutines/coroutines-guide.html)，共享更多的代码来提升效率。
 
-However, the current Kotlin/Native concurrency model has a number of deficiencies. For example, mobile developers are used to freely 
-sharing their objects between threads, and they have already developed a number of approaches and architectural patterns to 
-avoid data races while doing so. It is possible to write efficient applications that do not block the main thread using 
-Kotlin/Native, but the ability to do so comes with a steep learning curve.
+然而，目前 Kotlin/Native 的并发模型仍有一些不足之处。例如，移动开发者已经习惯了在线程之间自由地共享状态，并开发了一系列的方法和架构模式避免数据竞争。虽然使用 Kotlin/Native 可以在不阻塞主线程的情况下编写高效应用程序，但是学习成本过高。
 
-That's why we are working on creating a new memory manager and concurrency model for Kotlin/Native that will help us remove these 
-drawbacks. Learn more about [where we are going with this](https://blog.jetbrains.com/kotlin/2020/07/kotlin-native-memory-management-roadmap/).
+所以我们正在为 Kotlin/Native 开发一个全新的内存管理和并发模型，以便消除这些弊端。了解更多关于[我们的进展](https://blog.jetbrains.com/kotlin/2020/07/kotlin-native-memory-management-roadmap/)。
 
 _This material was prepared by [Touchlab](https://touchlab.co/) for publication by JetBrains._


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在主仓库的 [issue #35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [x] 已仔细阅读中文站 repo [issue⁠35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 及其中链接的内容
- [x] 阅读过 Kotlin 参考的大部分章节
- [x] 每一句都已经过谷歌机翻作为参考
- [x] 每一句都已经过搜狗机翻作为参考
- [x] 翻译中所用术语均与术语表中一致
- [x] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`，`[//]: # (title: Xxxx) [//]: # (auxiliary-id: Xxxx)`
- [x] 正文与注释中的标点均已使用全角
- [x] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [x] 英文与标点之间未留空格
- [x] <del>行级对照，中文句子中间断行处已使用 HTML 注释</del>
